### PR TITLE
[BUGFIX] : QR 결제 페이지 useEffect 두번 호출 이슈 해결

### DIFF
--- a/front/src/api/auth/index.ts
+++ b/front/src/api/auth/index.ts
@@ -95,14 +95,12 @@ const Auth = {
     }
   },
   // 비밀번호 변경
-  async v1UpdatePassword(memberId: number, password: string) {
+  async v1UpdatePassword(email: string, password: string) {
     try {
       const url = `${prefix}/pwd`;
       const result = await instance.put(url, {
-        data: {
-          memberId,
-          password,
-        },
+        email,
+        password,
       });
       return result;
     } catch (err) {

--- a/front/src/components/auth/PasswordForm.tsx
+++ b/front/src/components/auth/PasswordForm.tsx
@@ -1,41 +1,206 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import TextField from '../common/TextField';
 import TextButton from '../common/TextButton';
+import emailSuccessIcon from '../../assets/images/emailSuccess.svg';
+import emailFailIcon from '../../assets/images/emailFail.svg';
 import '../../styles/components/auth/passwordForm.scss';
+import { validPasswordReg } from '../../utils/func/ValidFunc';
+import { ErrorType } from './types';
+import { isShowError } from '../common/ToastBox';
+// api
+import Api from '../../api/auth';
 
 const PasswordForm = () => {
-  const [password, setPassword] = useState<string>('');
+  const navigate = useNavigate();
+  const [email, setEmail] = useState<string>('');
   const [newPassword, setNewPassword] = useState<string>('');
   const [newConfirmPassword, setNewConfirmPassword] = useState<string>('');
-
-  const changePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPassword(e.target.value);
-  };
+  const [error, setError] = useState<ErrorType>({
+    passwordCheck: true,
+    confirmPassword: true,
+    isError: false,
+    subErrorMessage: '',
+    errorMessage: '',
+  });
+  const [emailCodeCheck, setEmailCodeCheck] = useState<string>('before');
+  const [emailCode, setEmailCode] = useState<string>('');
+  const [code, setCode] = useState<string>('');
 
   const changeNewPassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!validPasswordReg(e.target.value)) {
+      setError({
+        ...error,
+        subErrorMessage:
+          '영문, 숫자, 특수문자를 조합하여 8-20자리로 입력해 주세요',
+        passwordCheck: false,
+        errorMessage: '',
+        isError: false,
+      });
+    } else {
+      setError({
+        ...error,
+        subErrorMessage: '',
+        passwordCheck: false,
+        errorMessage: '',
+        isError: false,
+      });
+    }
     setNewPassword(e.target.value);
   };
 
   const changeNewConfirmPassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (newPassword !== e.target.value) {
+      setError({
+        ...error,
+        subErrorMessage: '비밀번호가 일치하지 않습니다',
+        confirmPassword: false,
+        errorMessage: '',
+        isError: false,
+      });
+    } else {
+      setError({
+        ...error,
+        subErrorMessage: '',
+        confirmPassword: true,
+        errorMessage: '',
+        isError: false,
+      });
+    }
     setNewConfirmPassword(e.target.value);
   };
 
   const changePwd = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // TODO : password change api logic
+
+    if (emailCodeCheck !== 'success') {
+      handleError('이메일 인증을 해주세요', true);
+      return;
+    }
+    if (newPassword !== newConfirmPassword) {
+      handleError('비밀번호를 확인해주세요', true);
+      return;
+    }
+
+    Api.v1UpdatePassword(email, newPassword).then((res) => {
+      if (res.data.code === 200) {
+        isShowError('비밀번호가 변경되었습니다.');
+        navigate(-1);
+      } else {
+        isShowError('비밀번호 변경에 실패하였습니다.');
+      }
+    });
+  };
+
+  const handleError = (errMsg: string, isErr: boolean) => {
+    setError({
+      ...error,
+      errorMessage: errMsg,
+      isError: isErr,
+    });
+  };
+
+  const changeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+    setError({
+      ...error,
+      subErrorMessage: '',
+      errorMessage: '',
+      isError: false,
+    });
+  };
+
+  const changeEmailCode = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmailCode(e.target.value);
+    setError({
+      ...error,
+      subErrorMessage: '',
+      errorMessage: '',
+      isError: false,
+    });
+    setEmailCodeCheck('before');
+  };
+
+  const handleEmailCodeCheck = () => {
+    if (code === emailCode) {
+      setEmailCodeCheck('success');
+    } else {
+      setEmailCodeCheck('fail');
+      setError({
+        ...error,
+        subErrorMessage: '잘못된 인증 코드입니다',
+      });
+    }
+  };
+
+  const sendEmailCode = () => {
+    Api.v1EmailPwdValidation(email).then((res) => {
+      if (res.data.code === 200) {
+        const { code } = res.data.data;
+        setCode(code);
+        isShowError('인증 코드를 발송했습니다.');
+      } else {
+        isShowError('유효하지 않은 이메일입니다.');
+      }
+    });
+  };
+
+  const emailCodeCheckBtn: { [key: string]: JSX.Element } = {
+    before: (
+      <TextButton type={'button'} text="확인" onClick={handleEmailCodeCheck} />
+    ),
+    success: (
+      <span className="email-check__btn">
+        <img
+          src={emailSuccessIcon}
+          width={20}
+          height={20}
+          alt="Email Check Success Icon"
+        />
+      </span>
+    ),
+    fail: (
+      <span className="email-check__btn">
+        <img
+          src={emailFailIcon}
+          width={18}
+          height={18}
+          alt="Email Check Fail Icon"
+        />
+      </span>
+    ),
   };
 
   return (
     <form className="pwd-form" onSubmit={changePwd}>
       <div className="pwd-form__field">
-        <label htmlFor="password">기존 비밀번호</label>
-        <TextField
-          id="password"
-          placeholder="비밀번호를 입력해주세요"
-          inputType="pw"
-          textType="password"
-          onChangeText={changePassword}
-        />
+        <label htmlFor="email">이메일</label>
+        <div className="email-check">
+          <TextField
+            id="email"
+            placeholder="이메일을 입력해주세요."
+            onChangeText={changeEmail}
+          />
+          <TextButton
+            type={'button'}
+            text="코드 발송"
+            onClick={sendEmailCode}
+          />
+        </div>
+      </div>
+      <div className="pwd-form__field">
+        <label htmlFor="emailCode">이메일 인증 코드</label>
+        <div className="email-check">
+          <TextField
+            id="emailCode"
+            placeholder="인증 코드를 입력해주세요."
+            onChangeText={changeEmailCode}
+          />
+          {emailCodeCheckBtn[emailCodeCheck]}
+        </div>
+        {emailCodeCheck === 'fail' && (
+          <span className="error">{error.subErrorMessage}</span>
+        )}
       </div>
       <div className="pwd-form__field">
         <label htmlFor="newPassword">신규 비밀번호</label>
@@ -46,6 +211,9 @@ const PasswordForm = () => {
           textType="password"
           onChangeText={changeNewPassword}
         />
+        {!error.passwordCheck && (
+          <div className="error">{error.subErrorMessage}</div>
+        )}
       </div>
       <div className="pwd-form__field">
         <label htmlFor="newConfirmPassword">신규 비밀번호 확인</label>
@@ -56,11 +224,14 @@ const PasswordForm = () => {
           textType="password"
           onChangeText={changeNewConfirmPassword}
         />
+        {!error.confirmPassword && (
+          <div className="error">{error.subErrorMessage}</div>
+        )}
       </div>
       <div className="pwd-form__field btn">
         <TextButton type={'submit'} text="변경하기" />
       </div>
-      <div className="error">비밀번호가 다릅니다.</div>
+      {error.isError && <div className="error">{error.errorMessage}</div>}
     </form>
   );
 };

--- a/front/src/components/mypage/userInfo/UserInfo.tsx
+++ b/front/src/components/mypage/userInfo/UserInfo.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import UpdateUserInfo from './UpdateUserInfo';
 import ShowUserInfo from '../ShowUserInfo';
 import '../../../styles/components/mypage/userInfo/userInfo.scss';
@@ -10,6 +11,7 @@ import { getUserId, clearToken } from '../../../utils/tokenControl';
 import { isShowError } from '../../../components/common/ToastBox';
 
 const UserInfo = () => {
+  const navigate = useNavigate();
   const userId = typeof window !== 'undefined' && getUserId();
   const [userInfo, setUserInfo] = useState({
     email: '',
@@ -138,7 +140,7 @@ const UserInfo = () => {
         )}
       </div>
       <div className="userInfo-btn__container">
-        <button>비밀번호변경</button>
+        <button onClick={() => navigate('/pwd')}>비밀번호 변경</button>
         <button onClick={handlerMemberDelete}>회원탈퇴</button>
       </div>
     </div>

--- a/front/src/components/reservation/modal/ReservationInfoModal.tsx
+++ b/front/src/components/reservation/modal/ReservationInfoModal.tsx
@@ -20,6 +20,7 @@ const ReservationInfoModal = ({
 
   const onClickEvent = () => {
     handleSubmit();
+    onClickClose();
   };
   const onClickClose = () => {
     onClose();

--- a/front/src/pages/RedirectPage.tsx
+++ b/front/src/pages/RedirectPage.tsx
@@ -12,6 +12,7 @@ import {
   setRole,
 } from '../utils/tokenControl';
 import { setSocialLogin } from '../store/modules/auth';
+import { isShowError } from '../components/common/ToastBox';
 
 const RedirectPage = () => {
   const navigate = useNavigate();
@@ -25,16 +26,20 @@ const RedirectPage = () => {
       setLoading(true);
       await Api.v1KakaoLogin(code)
         .then((res) => {
-          const { member } = res.data.data;
-          dispatch(setSocialLogin());
-          setLoading(false);
-          setUserId(`${member.memberId}`);
-          setNickName(member.nickname);
-          setAccessToken(member.accessToken);
-          setRefreshToken(member.refreshToken);
-          setRole(member.role);
-          navigate('/main');
-          dispatch(showToast('로그인을 성공하였습니다.'));
+          if (res.data.code === 200) {
+            const { member } = res.data.data;
+            dispatch(setSocialLogin());
+            setLoading(false);
+            setUserId(`${member.memberId}`);
+            setNickName(member.nickname);
+            setAccessToken(member.accessToken);
+            setRefreshToken(member.refreshToken);
+            setRole(member.role);
+            navigate('/main');
+            dispatch(showToast('로그인을 성공하였습니다.'));
+          } else {
+            isShowError('에러가 발생하였습니다.');
+          }
         })
         .catch((err) => {
           navigate('/login');

--- a/front/src/styles/components/auth/passwordForm.scss
+++ b/front/src/styles/components/auth/passwordForm.scss
@@ -4,14 +4,14 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    height: 410px;
+    height: 500px;
     margin: 43px 73px;
 
     &__field {
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        width: 350px;
+        width: 400px;
         margin-bottom: 9px;
 
         &.btn {


### PR DESCRIPTION
## 작업사항
- QR 결제 페이지 useEffect 두번 호출 이슈 해결
- 비밀번호 찾기/변경 기능 구현

## 비고
- QR 결제 페이지 useEffect 두번 호출 이슈 해결 -> useModals 부분 이전에 open된 modal을 handleSubmit하기 전에 close해줘서 중첩을 없애줌
- 카카오 소셜 로그인 예외처리

## Github 이슈
- [비밀번호 찾기/변경 기능 구현](https://github.com/KangHayeonn/pickplace-client/issues/116#issue-1834329756)

## 작업일자
- 2023.08.10 ~ 2023.08.11

<br>
